### PR TITLE
Fix find-issue doesn't work first time after click Next page

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -92,7 +92,7 @@ class App extends React.Component {
     if (shouldResetPageNum) {
       preFetchState.pageNum = 1;
     }
-    this.setState(preFetchState);
+    await this.setState(preFetchState);
 
     const finalUrl = this.createUrl();
     await fetch(finalUrl)


### PR DESCRIPTION
This PR Fix the bug discussed on [issue#71](https://github.com/trybick/issue-collab/issues/71): 

- Click Find Issues
- Scroll to bottom of page and click Next page
- Click Find Issues again (observe it doesn't work)
- Click Find Issues a second time (observe it loads the first page)

I spent quite a while, and turns out I can fix it in a line of code.

It just because setState is asynchronous, we called createUrl() before we actually change the value of this.states