### PR TITLE
Add underline style to card titles

### DIFF
--- a/src/components/search/SearchResult.scss
+++ b/src/components/search/SearchResult.scss
@@ -22,7 +22,7 @@
 
     .link-title {
       font-family: 'Roboto Mono', monospace;
-      text-decoration: none;
+      text-decoration: underline;
       font-size: 1.4rem;
     }
   }


### PR DESCRIPTION
Added underline to title of every search result and closes #79 

### Before

<img width="820" alt="Screen Shot 2021-10-04 at 12 56 29 AM" src="https://user-images.githubusercontent.com/12704461/135764294-fd34c956-e950-475b-b3d4-82108d86e42d.png">

### After

<img width="815" alt="Screen Shot 2021-10-04 at 12 56 20 AM" src="https://user-images.githubusercontent.com/12704461/135764275-ac306f60-756a-4b64-a5d5-8e5b84a7d9e3.png">